### PR TITLE
Cleanup volumes when deleting, bump timeout.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,6 @@ integration_test:
 		up --exit-code-from client client
 	docker-compose \
 		-f ./integration/docker-compose.yaml \
-		logs dind
-	docker-compose \
-		-f ./integration/docker-compose.yaml \
 		down -v
 
 .PHONY: unit_test
@@ -58,7 +55,7 @@ lint:
 vendor:
 	go mod download
 
-install: build
+install:
 	mv ${DIST_DIR}/sind $${GOPATH}/bin/sind
 
 build: clean dist binary

--- a/cli/root.go
+++ b/cli/root.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	clusterName = ""
-	timeout     = 10 * time.Second
+	timeout     = 30 * time.Second
 )
 
 var rootCmd = &cobra.Command{
@@ -21,7 +21,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.Flags().StringVarP(&clusterName, "cluster", "c", "sind_default", "Cluster name.")
-	rootCmd.Flags().DurationVarP(&timeout, "timeout", "t", 10*time.Second, "Command timeout.")
+	rootCmd.Flags().DurationVarP(&timeout, "timeout", "t", timeout, "Command timeout.")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/sind/delete.go
+++ b/sind/delete.go
@@ -45,7 +45,14 @@ func (c *Cluster) deleteContainers(ctx context.Context) error {
 	for _, container := range containers {
 		cid := container.ID
 		errg.Go(func() error {
-			return client.ContainerRemove(ctx, cid, types.ContainerRemoveOptions{Force: true})
+			return client.ContainerRemove(
+				ctx,
+				cid,
+				types.ContainerRemoveOptions{
+					Force:         true,
+					RemoveVolumes: true,
+				},
+			)
 		})
 	}
 


### PR DESCRIPTION
## What does this PR do ?

- Bumps the default command timeout to 30 seconds instead of 10.
- It indicates to remove volumes of containers when deleting the cluster.

Fixes: #5 