### PR TITLE
Allows specifying a custom image name for nodes

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ blocks:
             - checkout
             - make toolbox
             - cache restore go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum),go-mod-$SEMAPHORE_GIT_BRANCH,go-mod-master
-            - ./tool/box make vendor
+            - ./toolbox make vendor
             - cache store go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum) ./.gocache
 
   - name: Test
@@ -27,10 +27,10 @@ blocks:
       jobs:
         - name: Lint
           commands:
-            - tool/box make lint
+            - ./toolbox make lint
         - name: Unit
           commands:
-            - tool/box make unit_test
+            - ./toolbox make unit_test
         - name: Integration
           commands:
             - make integration_test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,20 +8,31 @@ agent:
 blocks:
   - name: Install dependencies
     task:
+      secrets:
+        - sind-gh-token
+      prologue:
+        commands:
+            - sudo curl -sfL https://raw.githubusercontent.com/mmatur/checkout-semaphoreci2/master/godownloader.sh | sudo bash -s -- -b $GOPATH/bin v0.0.3
+            - checkout-semaphoreci2 --owner=jlevesy --repo=go-sind --required.pr && CHECKOUT_EXIT=$?
+            - if [ ${CHECKOUT_EXIT} -eq 0 ]; then echo OK; else exit 0; fi
+            - cache restore go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum),go-mod-$SEMAPHORE_GIT_BRANCH,go-mod-master
+            - make toolbox
       jobs:
         - name: make vendor and cache
           commands:
-            - checkout
-            - make toolbox
             - cache restore go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum),go-mod-$SEMAPHORE_GIT_BRANCH,go-mod-master
             - ./toolbox make vendor
             - cache store go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum) ./.gocache
 
   - name: Test
     task:
+      secrets:
+        - sind-gh-token
       prologue:
         commands:
-            - checkout
+            - sudo curl -sfL https://raw.githubusercontent.com/mmatur/checkout-semaphoreci2/master/godownloader.sh | sudo bash -s -- -b $GOPATH/bin v0.0.3
+            - checkout-semaphoreci2 --owner=jlevesy --repo=go-sind --required.pr && CHECKOUT_EXIT=$?
+            - if [ ${CHECKOUT_EXIT} -eq 0 ]; then echo OK; else exit 0; fi
             - cache restore go-mod-$SEMAPHORE_GIT_BRANCH-$(checksum go.sum),go-mod-$SEMAPHORE_GIT_BRANCH,go-mod-master
             - make toolbox
       jobs:

--- a/Dockerfile.toolbox
+++ b/Dockerfile.toolbox
@@ -1,4 +1,4 @@
-FROM golang:1.11.5-stretch
+FROM golang:1.12-stretch
 
 ARG UID
 ARG GID

--- a/cli/create.go
+++ b/cli/create.go
@@ -15,7 +15,7 @@ var (
 	workers       int
 	networkName   string
 	portsMapping  []string
-	nodeImageName = string
+	nodeImageName string
 
 	createCmd = &cobra.Command{
 		Use:   "create",

--- a/cli/create.go
+++ b/cli/create.go
@@ -3,17 +3,19 @@ package cli
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 
 	"github.com/jlevesy/go-sind/sind"
 )
 
 var (
-	managers     int
-	workers      int
-	networkName  string
-	portsMapping []string
+	managers      int
+	workers       int
+	networkName   string
+	portsMapping  []string
+	nodeImageName = string
 
 	createCmd = &cobra.Command{
 		Use:   "create",
@@ -29,6 +31,7 @@ func init() {
 	createCmd.Flags().IntVarP(&workers, "workers", "w", 0, "Amount of workers in the created cluster.")
 	createCmd.Flags().StringVarP(&networkName, "network_name", "n", "sind_default", "Name of the network to create.")
 	createCmd.Flags().StringSliceVarP(&portsMapping, "ports", "p", []string{}, "Ingress network port binding.")
+	createCmd.Flags().StringVarP(&nodeImageName, "image", "i", "docker:18.09-dind", "Name of the image to use for the nodes.")
 }
 
 func runCreate(cmd *cobra.Command, args []string) {

--- a/sind/create.go
+++ b/sind/create.go
@@ -29,8 +29,12 @@ const (
 )
 
 const (
-	dockerDINDimage        = "docker:dind"
 	defaultSwarmListenAddr = "0.0.0.0:2377"
+)
+
+const (
+	// DefaultNodeImageName is the default image name to use for creating swarm nodes.
+	DefaultNodeImageName = "docker:18.09-dind"
 )
 
 // CreateClusterParams are args to pass to CreateCluster.
@@ -74,7 +78,7 @@ func (n *CreateClusterParams) imageName() string {
 		return n.ImageName
 	}
 
-	return dockerDINDimage
+	return DefaultNodeImageName
 }
 
 // CreateCluster creates a new swarm cluster.


### PR DESCRIPTION
This PR introduces the following changes:

- The default image used for node (both manager and workers) bumped from `docker:dind` (aka. latest) to `docker:18.09-dind` (aka. latest patched version on the Docker CE edition 18.09).
- A new flag `--image` for the command `sind create`, to specify another docker image than the default `docker:18.09-dind`