### PR TITLE
Disable pull image by default, add force pull option

### DIFF
--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -33,7 +33,7 @@ func init() {
 	createCmd.Flags().StringVarP(&networkName, "network_name", "n", "sind_default", "Name of the network to create.")
 	createCmd.Flags().StringSliceVarP(&portsMapping, "ports", "p", []string{}, "Ingress network port binding.")
 	createCmd.Flags().StringVarP(&nodeImageName, "image", "i", "docker:18.09-dind", "Name of the image to use for the nodes.")
-	createCmd.Flags().BoolVarP(&pull, "pull", "", false, "Force pull image.")
+	createCmd.Flags().BoolVarP(&pull, "pull", "", false, "Pull node image before creating the cluster.")
 }
 
 func runCreate(cmd *cobra.Command, args []string) {
@@ -60,7 +60,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 		ClusterName:  clusterName,
 		PortBindings: portsMapping,
 		ImageName:    nodeImageName,
-		ForcePull:    pull,
+		PullImage:    pull,
 	}
 
 	cluster, err := sind.CreateCluster(ctx, clusterParams)

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -16,6 +16,7 @@ var (
 	networkName   string
 	portsMapping  []string
 	nodeImageName string
+	pull          bool
 
 	createCmd = &cobra.Command{
 		Use:   "create",
@@ -32,6 +33,7 @@ func init() {
 	createCmd.Flags().StringVarP(&networkName, "network_name", "n", "sind_default", "Name of the network to create.")
 	createCmd.Flags().StringSliceVarP(&portsMapping, "ports", "p", []string{}, "Ingress network port binding.")
 	createCmd.Flags().StringVarP(&nodeImageName, "image", "i", "docker:18.09-dind", "Name of the image to use for the nodes.")
+	createCmd.Flags().BoolVarP(&pull, "pull", "", false, "Force pull image.")
 }
 
 func runCreate(cmd *cobra.Command, args []string) {
@@ -58,6 +60,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 		ClusterName:  clusterName,
 		PortBindings: portsMapping,
 		ImageName:    nodeImageName,
+		ForcePull:    pull,
 	}
 
 	cluster, err := sind.CreateCluster(ctx, clusterParams)

--- a/pkg/sind/create.go
+++ b/pkg/sind/create.go
@@ -47,7 +47,7 @@ type CreateClusterParams struct {
 	Workers  int
 
 	ImageName    string
-	ForcePull    bool
+	PullImage    bool
 	PortBindings []string
 }
 
@@ -96,7 +96,7 @@ func CreateCluster(ctx context.Context, params CreateClusterParams) (*Cluster, e
 
 	imageExist := imageAlreadyExist(ctx, hostClient, params.imageName())
 
-	if params.ForcePull || !imageExist {
+	if params.PullImage || !imageExist {
 		out, err := hostClient.ImagePull(ctx, params.imageName(), types.ImagePullOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("unable to pull the %s image: %v", params.imageName(), err)


### PR DESCRIPTION
### Description

This PR adds a new flag to force pulling image when we create a new sind cluster.

With this PR, sind will pull image if it does not exist on the filesystem or if the flat `pull` is enabled