### PR TITLE
fix: be able to customize cluster name with create command

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -20,8 +20,8 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&clusterName, "cluster", "c", "sind_default", "Cluster name.")
-	rootCmd.Flags().DurationVarP(&timeout, "timeout", "t", 30*time.Second, "Command timeout.")
+	rootCmd.PersistentFlags().StringVarP(&clusterName, "cluster", "c", "sind_default", "Cluster name.")
+	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 30*time.Second, "Command timeout.")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
### Description

This PR fix an issue with the cluster name that was not usable in subcommand. 