### PR TITLE
feat: Add version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,9 @@
 project_name: sind
-before:
-  hooks:
-    - go mod download
 builds:
   - main: ./cmd/sind/main.go
     binary: sind
     ldflags:
-      - "-s -w"
+      - -s -w -X "github.com/jlevesy/sind/pkg/cli.version={{ .Version }}"
     env:
     - CGO_ENABLED=0
 archive:

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ build: clean dist binary
 
 .PHONY: binary
 binary:
-	CGO_ENABLED=0 go build -ldflags="-s -w"  -o $(DIST_DIR)/sind ./cmd/sind
+	CGO_ENABLED=0 go build -ldflags='-s -w -X "github.com/jlevesy/sind/pkg/cli.version=custom-$(shell git rev-parse --short HEAD)" ' -o $(DIST_DIR)/sind ./cmd/sind
 
 dist:
 	mkdir -p $(DIST_DIR)

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "unknown"
+)
+
+var (
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Prints sind version.",
+		Run:   runVersion,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func runVersion(cmd *cobra.Command, args []string) {
+	fmt.Println(version)
+}

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -23,5 +24,6 @@ func init() {
 }
 
 func runVersion(cmd *cobra.Command, args []string) {
-	fmt.Println(version)
+	fmt.Printf("Version: %s\n", version)
+	fmt.Printf("Go version: %s\n", runtime.Version()[2:])
 }


### PR DESCRIPTION
This PR adds `sind version` command and makes goreleaser inject release version.

Fixes: #28 