### PR TITLE
chore: remove manual release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,6 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run: curl -sL https://git.io/goreleaser | bash
-      - run: make release
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ all: clean build test
 #	Release targets
 #
 
-.PHONY: release
-release: clean
-	goreleaser
-
 .PHONY: dry_release
 dry_release: clean
 	goreleaser --skip-publish


### PR DESCRIPTION
As the CI release workflow is now operational, we remove the `make release` target.
Also, it removes the useless call to `make release` in the release job.