### PR TITLE
fix: Correct container hostnames

### DIFF
--- a/pkg/sind/create.go
+++ b/pkg/sind/create.go
@@ -249,13 +249,13 @@ func CreateCluster(ctx context.Context, params CreateClusterParams) (*Cluster, e
 		return nil, fmt.Errorf("unable to collect join tokens: %v", err)
 	}
 
-	var errg errgroup.Group
+	errg, groupCtx := errgroup.WithContext(ctx)
 	managerAddr := net.JoinHostPort(primaryNodeCID[0:12], "2377")
 	for _, managerID := range managerNodeCIDs {
 		cid := managerID
 		errg.Go(func() error {
 			return execContainer(
-				ctx,
+				groupCtx,
 				hostClient,
 				cid,
 				[]string{
@@ -274,7 +274,7 @@ func CreateCluster(ctx context.Context, params CreateClusterParams) (*Cluster, e
 		cid := workerID
 		errg.Go(func() error {
 			return execContainer(
-				ctx,
+				groupCtx,
 				hostClient,
 				cid,
 				[]string{

--- a/pkg/sind/delete.go
+++ b/pkg/sind/delete.go
@@ -42,12 +42,12 @@ func (c *Cluster) deleteContainers(ctx context.Context) error {
 		return fmt.Errorf("unable to get container list: %v", err)
 	}
 
-	var errg errgroup.Group
+	errg, groupCtx := errgroup.WithContext(ctx)
 	for _, container := range containers {
 		cid := container.ID
 		errg.Go(func() error {
 			return client.ContainerRemove(
-				ctx,
+				groupCtx,
 				cid,
 				types.ContainerRemoveOptions{
 					Force:         true,
@@ -82,11 +82,12 @@ func (c *Cluster) deleteNetwork(ctx context.Context) error {
 	if len(networks) == 0 {
 		return errors.New(ErrNetworkNotFound)
 	}
-	var errg errgroup.Group
+
+	errg, groupCtx := errgroup.WithContext(ctx)
 	for _, network := range networks {
 		netID := network.ID
 		errg.Go(func() error {
-			return client.NetworkRemove(ctx, netID)
+			return client.NetworkRemove(groupCtx, netID)
 		})
 	}
 


### PR DESCRIPTION
This PR makes sure that node hostnames are set correctly.

```
(22 ms) (╯°o°）╯ ┻━┻ sind fix/container-hostnames λ docker node ls
ID                            HOSTNAME                 STATUS              AVAILABILITY        MANAGER STATUS      ENGINE VERSION
l3bi013zoib1m8l925qt6encr *   sind_default-manager-0   Ready               Active              Leader              18.09.3
n3d4mn4un53v8pzaiub8scmlw     sind_default-manager-1   Ready               Active              Reachable           18.09.3
hq6c52g5aer2ubi9u8lnntxon     sind_default-manager-2   Ready               Active              Reachable           18.09.3
wvfpyv3nodsr2qbquwhef738s     sind_default-worker-0    Ready               Active                                  18.09.3
i2avlhgeds24playn3iw30e8q     sind_default-worker-1    Ready               Active                                  18.09.3
q2ps1rpgogw2kaxemxlfqs5do     sind_default-worker-2    Ready               Active                                  18.09.3
```

It also generalize the usage of `errgroup` and `errgroup.WithContext`, which simplifies the code.