### PR TITLE
Chore: Bump CI environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   install:
     working_directory: ~/sind
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.6
     steps:
       - checkout
       - restore_cache:
@@ -26,8 +26,8 @@ jobs:
           name: Install and Setup Go
           command: |
             sudo rm -rf /usr/local/go
-            curl -sSfL https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz -o go.tgz
-            echo "2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec *go.tgz" | sha256sum -c -
+            curl -sSfL https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz -o go.tgz
+            echo "dbcf71a3c1ea53b8d54ef1b48c85a39a6c9a935d01fc8291ff2b92028e59913c *go.tgz" | sha256sum -c -
             sudo tar --overwrite -C /usr/local -xzf go.tgz
             rm go.tgz
             sudo mkdir -p "/go/{pkg/mod,src,bin}" && sudo chmod -R 777 /go
@@ -43,7 +43,7 @@ jobs:
 
   unit_test:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.6
     working_directory: ~/sind
     steps:
       - checkout
@@ -63,7 +63,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: circleci/golang:1.12.6
     working_directory: ~/sind
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run:
           name: "Install golangci-lint"
           command: |
-            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.15.0
+            curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.17.1
             sudo mv ./bin/golangci-lint $GOPATH/bin
             rm -rf ./bin
             golangci-lint --version

--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -78,5 +78,5 @@ func runCreate(cmd *cobra.Command, args []string) {
 	}
 
 	disgo.EndStep()
-	disgo.Infof("%s Cluster %q successfuly created\n", style.Success(style.SymbolCheck), clusterName)
+	disgo.Infof("%s Cluster %q successfully created\n", style.Success(style.SymbolCheck), clusterName)
 }

--- a/pkg/cli/delete.go
+++ b/pkg/cli/delete.go
@@ -54,5 +54,5 @@ func runDelete(cmd *cobra.Command, args []string) {
 	}
 
 	disgo.EndStep()
-	disgo.Infof("%s Cluster %q successfuly deleted !\n", style.Success(style.SymbolCheck), clusterName)
+	disgo.Infof("%s Cluster %q successfully deleted !\n", style.Success(style.SymbolCheck), clusterName)
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -53,5 +53,5 @@ func runStart(cmd *cobra.Command, args []string) {
 	}
 
 	disgo.EndStep()
-	disgo.Infof("%s Cluster %q successfuly started\n", style.Success(style.SymbolCheck), clusterName)
+	disgo.Infof("%s Cluster %q successfully started\n", style.Success(style.SymbolCheck), clusterName)
 }

--- a/pkg/cli/stop.go
+++ b/pkg/cli/stop.go
@@ -53,5 +53,5 @@ func runStop(cmd *cobra.Command, args []string) {
 	}
 
 	disgo.EndStep()
-	disgo.Infof("%s Cluster %q successfuly stopped\n", style.Success(style.SymbolCheck), clusterName)
+	disgo.Infof("%s Cluster %q successfully stopped\n", style.Success(style.SymbolCheck), clusterName)
 }


### PR DESCRIPTION
This PR bumps CI environment:

- golang to 1.12.6
- golangci-lint to 1.17.1