### PR TITLE
Make sind push accept a jobs option

### DIFF
--- a/pkg/cli/push.go
+++ b/pkg/cli/push.go
@@ -21,12 +21,14 @@ var (
 	}
 
 	filePath string
+	jobs     int
 )
 
 func init() {
 	rootCmd.AddCommand(pushCmd)
 
 	pushCmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to an image archive.")
+	pushCmd.Flags().IntVarP(&jobs, "jobs", "j", 1, "How many pushes in parallel (0 means auto).")
 }
 
 func runPush(cmd *cobra.Command, args []string) {
@@ -61,7 +63,7 @@ func runPush(cmd *cobra.Command, args []string) {
 
 	disgo.StartStepf("Pushing images %q to cluster %q", args, clusterName)
 
-	if err = sind.PushImageRefs(ctx, client, clusterInfo.Name, args); err != nil {
+	if err = sind.PushImageRefs(ctx, client, clusterInfo.Name, jobs, args); err != nil {
 		fail(disgo.FailStepf("Unable to push images %q to %q: %v", args, clusterName, err))
 	}
 
@@ -78,7 +80,7 @@ func pushFile(ctx context.Context, client *docker.Client, clusterName string, fi
 	}
 	defer file.Close()
 
-	if err = sind.PushImageFile(ctx, client, clusterName, file); err != nil {
+	if err = sind.PushImageFile(ctx, client, clusterName, jobs, file); err != nil {
 		fail(disgo.FailStepf("Unable to push image archive %q to %q: %v", filePath, clusterName, err))
 	}
 

--- a/pkg/sind/internal/container_test.go
+++ b/pkg/sind/internal/container_test.go
@@ -420,7 +420,7 @@ func TestCopyToContainers(t *testing.T) {
 		return nil
 	})
 
-	require.NoError(t, CopyToContainers(ctx, client, containers, fileContent.Name(), destPath))
+	require.NoError(t, CopyToContainers(ctx, client, containers, 2, fileContent.Name(), destPath))
 
 	close(contentSent)
 
@@ -487,7 +487,7 @@ func TestExecContainers(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, ExecContainers(ctx, &client, containers, cmd))
+	require.NoError(t, ExecContainers(ctx, &client, containers, 2, cmd))
 
 	close(execCreated)
 	close(execStarted)

--- a/pkg/test/push_test.go
+++ b/pkg/test/push_test.go
@@ -43,7 +43,7 @@ func TestSindCanPushAnImageToClusterFromRefs(t *testing.T) {
 	_, err = io.Copy(ioutil.Discard, out)
 	require.NoError(t, err)
 
-	require.NoError(t, sind.PushImageRefs(ctx, hostClient, params.ClusterName, []string{tag}))
+	require.NoError(t, sind.PushImageRefs(ctx, hostClient, params.ClusterName, 1, []string{tag}))
 
 	swarmHost, err := sind.ClusterHost(ctx, hostClient, params.ClusterName)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR allow sind push to accept a -j option to control how many nodes we provision in parallel.
This defaults is set to one, which is the most reliable, but can be set by the user.