### PR TITLE
Add the --daemon-arg flag

### DIFF
--- a/pkg/cli/create.go
+++ b/pkg/cli/create.go
@@ -18,6 +18,7 @@ var (
 	networkName   string
 	portsMapping  []string
 	nodeImageName string
+	daemonArgs    []string
 	pull          bool
 
 	createCmd = &cobra.Command{
@@ -34,6 +35,7 @@ func init() {
 	createCmd.Flags().Uint16VarP(&workers, "workers", "w", 0, "Amount of workers in the created cluster.")
 	createCmd.Flags().StringVarP(&networkName, "network-name", "n", "sind-default", "Name of the network to create.")
 	createCmd.Flags().StringSliceVarP(&portsMapping, "ports", "p", []string{}, "Ingress network port binding.")
+	createCmd.Flags().StringSliceVarP(&daemonArgs, "daemon-arg", "", []string{}, "Args to pass to nodes docker daemon")
 	createCmd.Flags().StringVarP(&nodeImageName, "image", "i", sind.DefaultNodeImageName, "Name of the image to use for the nodes.")
 	createCmd.Flags().BoolVarP(&pull, "pull", "", false, "Pull node image before creating the cluster.")
 }
@@ -74,6 +76,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 		PortBindings: portsMapping,
 		ImageName:    nodeImageName,
 		PullImage:    pull,
+		DaemonArgs:   daemonArgs,
 	}
 
 	if err := sind.CreateCluster(ctx, client, clusterConfig); err != nil {

--- a/pkg/sind/create.go
+++ b/pkg/sind/create.go
@@ -27,6 +27,7 @@ type ClusterConfiguration struct {
 	ImageName    string
 	PullImage    bool
 	PortBindings []string
+	DaemonArgs   []string
 }
 
 func (n *ClusterConfiguration) validate() error {
@@ -97,6 +98,8 @@ func CreateCluster(ctx context.Context, hostClient *docker.Client, params Cluste
 
 		Managers: params.Managers,
 		Workers:  params.Workers,
+
+		DaemonArgs: params.DaemonArgs,
 	}
 
 	nodecIDs, err := internal.CreateNodes(ctx, hostClient, nodesCfg)

--- a/pkg/sind/internal/node.go
+++ b/pkg/sind/internal/node.go
@@ -24,6 +24,8 @@ type NodesConfig struct {
 
 	Managers uint16
 	Workers  uint16
+
+	DaemonArgs []string
 }
 
 // NodeIDs carries the IDs of various nodes in the cluster.
@@ -77,10 +79,10 @@ func CreateNodes(ctx context.Context, docker nodeCreator, cfg NodesConfig) (*Nod
 					ClusterNameLabel: cfg.ClusterName,
 					NodeRoleLabel:    NodeRolePrimary,
 				},
-				Cmd: []string{
+				Cmd: append([]string{
 					"-H unix:///var/run/docker.sock",
 					"-H tcp://0.0.0.0:2375",
-				},
+				}, cfg.DaemonArgs...),
 			},
 			&container.HostConfig{
 				Privileged:      true,
@@ -133,6 +135,7 @@ func CreateNodes(ctx context.Context, docker nodeCreator, cfg NodesConfig) (*Nod
 						ClusterNameLabel: cfg.ClusterName,
 						NodeRoleLabel:    NodeRoleManager,
 					},
+					Cmd: cfg.DaemonArgs,
 				},
 				&container.HostConfig{Privileged: true},
 				&network.NetworkingConfig{
@@ -182,6 +185,7 @@ func CreateNodes(ctx context.Context, docker nodeCreator, cfg NodesConfig) (*Nod
 						ClusterNameLabel: cfg.ClusterName,
 						NodeRoleLabel:    NodeRoleWorker,
 					},
+					Cmd: cfg.DaemonArgs,
 				},
 				&container.HostConfig{Privileged: true},
 				&network.NetworkingConfig{

--- a/pkg/sind/internal/node_test.go
+++ b/pkg/sind/internal/node_test.go
@@ -58,6 +58,7 @@ func TestCreateNodes(t *testing.T) {
 		PortBindings: []string{"8080:8080"},
 		Managers:     3,
 		Workers:      3,
+		DaemonArgs:   []string{"--fake-arg"},
 	}
 
 	containerCreated := make(chan *fakeContainer, cfg.Managers+cfg.Workers)
@@ -121,7 +122,7 @@ func TestCreateNodes(t *testing.T) {
 			Image:        cfg.ImageRef,
 			ExposedPorts: nat.PortSet(map[nat.Port]struct{}{nat.Port("8080/tcp"): {}}),
 			Entrypoint:   []string{"dockerd"},
-			Cmd:          []string{"-H unix:///var/run/docker.sock", "-H tcp://0.0.0.0:2375"},
+			Cmd:          []string{"-H unix:///var/run/docker.sock", "-H tcp://0.0.0.0:2375", "--fake-arg"},
 			Labels: map[string]string{
 				"com.sind.cluster.name": "TestCluster",
 				"com.sind.cluster.role": "primary",
@@ -173,6 +174,7 @@ func TestCreateNodes(t *testing.T) {
 					"com.sind.cluster.name": "TestCluster",
 					"com.sind.cluster.role": "manager",
 				},
+				Cmd: []string{"--fake-arg"},
 			},
 			c.cConfig,
 		)
@@ -213,6 +215,7 @@ func TestCreateNodes(t *testing.T) {
 					"com.sind.cluster.name": "TestCluster",
 					"com.sind.cluster.role": "worker",
 				},
+				Cmd: []string{"--fake-arg"},
 			},
 			c.cConfig,
 		)


### PR DESCRIPTION
This commit defines the --daemon-arg flag allowing to pass a custom flag
to the dockerd command being run on each node.

This flag is useful for allowing the sind cluster to use a mirror
or an unsecure registry for instance.

For instance `sind create --managers=3 --workers=2 -p 55055:55055 --daemon-arg='--insecure-registry=http://42.42.42.42:5000'`